### PR TITLE
Remove ambiguity in ELB health check description

### DIFF
--- a/doc_source/target-group-health-checks.md
+++ b/doc_source/target-group-health-checks.md
@@ -10,7 +10,7 @@ Health checks do not support WebSockets\.
 
 ## Health Check Settings<a name="health-check-settings"></a>
 
-You configure health checks for the targets in a target group using the following settings\. The load balancer sends a health check request to each registered target every **HealthCheckIntervalSeconds** seconds, using the specified port, protocol, and ping path\. Each health check request is independent and lasts the entire interval\. The time it takes for the target to respond does not affect the interval for the next health check request\. If the health checks exceed **UnhealthyThresholdCount** consecutive failures, the load balancer takes the target out of service\. When the health checks exceed **HealthyThresholdCount** consecutive successes, the load balancer puts the target back in service\.
+You configure health checks for the targets in a target group using the following settings\. The load balancer sends a health check request to each registered target every **HealthCheckIntervalSeconds** seconds, using the specified port, protocol, and ping path\. Each health check request is independent and the result lasts the entire interval\. The time it takes for the target to respond does not affect the interval for the next health check request\. If the health checks exceed **UnhealthyThresholdCount** consecutive failures, the load balancer takes the target out of service\. When the health checks exceed **HealthyThresholdCount** consecutive successes, the load balancer puts the target back in service\.
 
 
 | Setting | Description | 

--- a/doc_source/target-group-health-checks.md
+++ b/doc_source/target-group-health-checks.md
@@ -10,7 +10,7 @@ Health checks do not support WebSockets\.
 
 ## Health Check Settings<a name="health-check-settings"></a>
 
-You configure health checks for the targets in a target group using the following settings\. The load balancer sends a health check request to each registered target every **HealthCheckIntervalSeconds** seconds, using the specified port, protocol, and ping path\. Each health check request is independent and the result lasts the entire interval\. The time it takes for the target to respond does not affect the interval for the next health check request\. If the health checks exceed **UnhealthyThresholdCount** consecutive failures, the load balancer takes the target out of service\. When the health checks exceed **HealthyThresholdCount** consecutive successes, the load balancer puts the target back in service\.
+You configure health checks for the targets in a target group using the following settings\. The load balancer sends a health check request to each registered target every **HealthCheckIntervalSeconds** seconds, using the specified port, protocol, and ping path\. Each health check request is independent and the result lasts for the entire interval\. The time it takes for the target to respond does not affect the interval for the next health check request\. If the health checks exceed **UnhealthyThresholdCount** consecutive failures, the load balancer takes the target out of service\. When the health checks exceed **HealthyThresholdCount** consecutive successes, the load balancer puts the target back in service\.
 
 
 | Setting | Description | 


### PR DESCRIPTION
Remove ambiguity that suggests the HTTP connection for the request is kept open for the entire interval, by clarifying that it is the *result* of the health check that lasts for the entire health check interval, rather than the request itself.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
