### PR TITLE
Update load-balancer-target-groups.md

### DIFF
--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -27,7 +27,7 @@ Target groups support the following protocols and ports:
 + **Protocols**: HTTP, HTTPS
 + **Ports**: 1\-65535
 
-If a target group is configured with the HTTPS protocol or uses HTTPS health checks, SSL connections to the targets use the security settings from the `ELBSecurityPolicy2016-08` policy\.
+If a target group is configured with the HTTPS protocol or uses HTTPS health checks, SSL/TLS connections to the targets use the security settings from the `ELBSecurityPolicy2016-08` policy\.
 
 ## Target Type<a name="target-type"></a>
 


### PR DESCRIPTION
*Description of changes:*
Clarified a bit as TLS is the protocol that ELBSecurityPolicy2016-08 is using.  Left it as SSL/TLS for SEO as people still search for SSL or might not fully understand the difference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
