### PR TITLE
Update create-https-listener.md

### DIFF
--- a/doc_source/create-https-listener.md
+++ b/doc_source/create-https-listener.md
@@ -63,7 +63,7 @@ You can manage certificate renewal and replacement as follows:
 
 Elastic Load Balancing uses a Secure Socket Layer \(SSL\) negotiation configuration, known as a security policy, to negotiate SSL connections between a client and the load balancer\. A security policy is a combination of protocols and ciphers\. The protocol establishes a secure connection between a client and a server and ensures that all data passed between the client and your load balancer is private\. A cipher is an encryption algorithm that uses encryption keys to create a coded message\. Protocols use several ciphers to encrypt data over the internet\. During the connection negotiation process, the client and the load balancer present a list of ciphers and protocols that they each support, in order of preference\. By default, the first cipher on the server's list that matches any one of the client's ciphers is selected for the secure connection\.
 
-Application Load Balancers do not support SSL renegotiation for client or target connections\.
+While Application Load Balancers do support back-end server encryption to your targets, Application Load Balancers do not support SSL renegotiation for client or target connections\.
 
 You can choose the security policy that is used for front\-end connections\. The `ELBSecurityPolicy-2016-08` security policy is always used for backend connections\. Application Load Balancers do not support custom security policies\.
 


### PR DESCRIPTION
*Description of changes:*
Clarified that ALBs support back-end encryption, because sometimes "renegotiation" is used in the incorrect context to mean that a LB terminates TLS and then re-encrypts (starts a new TLS session) to targets. However, the context of "renegotiation" here means something else in the TLS protocol. Some readers could be confused, so hoping this pull request can clarify the distinction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
