### PR TITLE
Update on how ALB updates the Stickeyness cookie.

### DIFF
--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -159,7 +159,7 @@ WebSockets connections are inherently sticky\. If the client requests a connecti
 
 You enable sticky sessions at the target group level\. You can also set the duration for the stickiness of the load balancer\-generated cookie, in seconds\. The duration is set with each request\. Therefore, if the client sends a request before each duration period expires, the sticky session continues\.
 
-If a target is deregistered or is unhealthy, a new target will be selected and the cookie will be updated to include the new routing information. and the subsequent requests using the cookie will be routed accordingly.
+If a target is deregistered or is unhealthy, a new target will be selected and the cookie will be updated to include the new routing information, subsequent requests using the cookie will be routed accordingly.
 
 **To enable sticky sessions using the console**
 

--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -153,11 +153,13 @@ Sticky sessions are a mechanism to route requests to the same target in a target
 
 When a load balancer first receives a request from a client, it routes the request to a target and generates a cookie to include in the response to the client\. The next request from that client contains the cookie\. If sticky sessions are enabled for the target group and the request goes to the same target group, the load balancer detects the cookie and routes the request to the same target\.
 
-Application Load Balancers support load balancer\-generated cookies only\. The name of the cookie is AWSALB\. The contents of these cookies are encrypted using a rotating key\. You cannot decrypt or modify load balancer\-generated cookies\.
+Application Load Balancers support load balancer\-generated cookies only\. The name of the cookie is AWSALB\. The contents of these cookies are encrypted using a rotating key and it is expected that every response sets an updated cookie\. You cannot decrypt or modify load balancer\-generated cookies\.
 
 WebSockets connections are inherently sticky\. If the client requests a connection upgrade to WebSockets, the target that returns an HTTP 101 status code to accept the connection upgrade is the target used in the WebSockets connection\. After the WebSockets upgrade is complete, cookie\-based stickiness is not used\.
 
 You enable sticky sessions at the target group level\. You can also set the duration for the stickiness of the load balancer\-generated cookie, in seconds\. The duration is set with each request\. Therefore, if the client sends a request before each duration period expires, the sticky session continues\.
+
+If a target is deregistered or is unhealthy, a new target will be selected and the cookie will be updated to include the new routing information. and the subsequent requests using the cookie will be routed accordingly.
 
 **To enable sticky sessions using the console**
 

--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -151,15 +151,13 @@ Use the [modify\-target\-group\-attributes](https://docs.aws.amazon.com/cli/late
 
 Sticky sessions are a mechanism to route requests to the same target in a target group\. This is useful for servers that maintain state information in order to provide a continuous experience to clients\. To use sticky sessions, the clients must support cookies\.
 
-When a load balancer first receives a request from a client, it routes the request to a target and generates a cookie to include in the response to the client\. The next request from that client contains the cookie\. If sticky sessions are enabled for the target group and the request goes to the same target group, the load balancer detects the cookie and routes the request to the same target\.
+When a load balancer first receives a request from a client, it routes the request to a target, generates a cookie named AWSALB\ that encodes information about the selected target, encrypts the cookie, and includes the cookie in the response to the client\. The client should include the cookie that it receives in subsequent requests to the load balancer\. When the load balancer receives a request from a client that contains the cookie, if sticky sessions are enabled for the target group and the request goes to the same target group, the load balancer detects the cookie and routes the request to the same target\. If the cookie is present but cannot be decoded, or if it refers to a target that was deregistered or is unhealthy, the load balancer selects a new target and updates the cookie with information about the new target\.
 
-Application Load Balancers support load balancer\-generated cookies only\. The name of the cookie is AWSALB\. The contents of these cookies are encrypted using a rotating key and it is expected that every response sets an updated cookie\. You cannot decrypt or modify load balancer\-generated cookies\.
+Application Load Balancers support load balancer\-generated cookies only\. The contents of these cookies are encrypted using a rotating key and it is expected that every response sets an updated cookie\. You cannot decrypt or modify load balancer\-generated cookies\.
 
 WebSockets connections are inherently sticky\. If the client requests a connection upgrade to WebSockets, the target that returns an HTTP 101 status code to accept the connection upgrade is the target used in the WebSockets connection\. After the WebSockets upgrade is complete, cookie\-based stickiness is not used\.
 
 You enable sticky sessions at the target group level\. You can also set the duration for the stickiness of the load balancer\-generated cookie, in seconds\. The duration is set with each request\. Therefore, if the client sends a request before each duration period expires, the sticky session continues\.
-
-If a target is deregistered or is unhealthy, a new target will be selected and the cookie will be updated to include the new routing information, subsequent requests using the cookie will be routed accordingly.
 
 **To enable sticky sessions using the console**
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated how ALB sets a cookie for every request and how a target is selected in case the old target deregisters or is down

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
