### PR TITLE
Include subdomains in the Host Condition description

### DIFF
--- a/doc_source/load-balancer-listeners.md
+++ b/doc_source/load-balancer-listeners.md
@@ -310,7 +310,7 @@ You can specify conditions when you create or modify a rule\. For more informati
 
 ### Host Conditions<a name="host-conditions"></a>
 
-You can use host conditions to define rules that route requests based on the host name in the host header \(also known as *host\-based routing*\)\. This enables you to support multiple domains using a single load balancer\.
+You can use host conditions to define rules that route requests based on the host name in the host header \(also known as *host\-based routing*\)\. This enables you to support multiple subdomains and different top-level domains using a single load balancer\.
 
 A hostname is not case\-sensitive, can be up to 128 characters in length, and can contain any of the following characters:
 + A–Z, a–z, 0–9


### PR DESCRIPTION


*Issue #, if available:* Subdomains for host-based routing.

*Description of changes:*

Host-based routing allows multiple subdomains and different top-level domains using a single load balancer. I understand that technically, a subdomain is also a hostname but I think, we can further improve the wording here since, in your example, the "test.example.com" is commonly called a "subdomain". In this way, the readers can easily understand that Host-based routing can support different subdomains of a given domain and different TLD domains as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
