### PR TITLE
Update load-balancer-target-groups.md

### DIFF
--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -52,7 +52,7 @@ When the target type is `ip`, you can specify IP addresses from one of the follo
 + 172\.16\.0\.0/12 \(RFC 1918\)
 + 192\.168\.0\.0/16 \(RFC 1918\)
 
-These supported CIDR blocks enable you to register the following with a target group: ClassicLink instances, instances in a VPC that is peered (same region or inter-region) to the load balancer VPC, AWS resources that are addressable by IP address and port \(for example, databases\), and on\-premises resources linked to AWS through AWS Direct Connect or a VPN connection\.
+These supported CIDR blocks enable you to register the following with a target group: ClassicLink instances, instances in a VPC that is peered to the load balancer VPC (same Region or different Region), AWS resources that are addressable by IP address and port \(for example, databases\), and on\-premises resources linked to AWS through AWS Direct Connect or a VPN connection\.
 
 **Important**  
 You can't specify publicly routable IP addresses\.

--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -52,7 +52,7 @@ When the target type is `ip`, you can specify IP addresses from one of the follo
 + 172\.16\.0\.0/12 \(RFC 1918\)
 + 192\.168\.0\.0/16 \(RFC 1918\)
 
-These supported CIDR blocks enable you to register the following with a target group: ClassicLink instances, instances in a VPC that is peered to the load balancer VPC, AWS resources that are addressable by IP address and port \(for example, databases\), and on\-premises resources linked to AWS through AWS Direct Connect or a VPN connection\.
+These supported CIDR blocks enable you to register the following with a target group: ClassicLink instances, instances in a VPC that is peered (same region or inter-region) to the load balancer VPC, AWS resources that are addressable by IP address and port \(for example, databases\), and on\-premises resources linked to AWS through AWS Direct Connect or a VPN connection\.
 
 **Important**  
 You can't specify publicly routable IP addresses\.


### PR DESCRIPTION
Line #55. Added "same region or inter-region" for added clarity as IP targets are reachable behind an ALB via same region or cross-region VPC peering.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
