### PR TITLE
Update load-balancer-limits.md

### DIFF
--- a/doc_source/load-balancer-limits.md
+++ b/doc_source/load-balancer-limits.md
@@ -30,7 +30,7 @@ Your AWS account has the following quotas related to Application Load Balancers\
 **Rule**
 + Target groups per action: 5
 + Match evaluations per rule: 5
-+ Wildcards per rule: 5
++ Wildcards per rule: 6
 + Actions per rule: 2 \(one optional authentication action, one required action\)
 
 **\*** This quota is shared by target groups for your Application Load Balancers and Network Load Balancers\.


### PR DESCRIPTION
upon attempting to update cloud formation template that updates a rule with more then 6 wildcards in it, it rolled back with an error stating the max wildcards you can use is 6. I updated the template again using the proposed limit and it is working. The documentation should change to reflect this new limit

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
