### PR TITLE
Added missing double-quotes to access log examples

### DIFF
--- a/doc_source/load-balancer-access-logs.md
+++ b/doc_source/load-balancer-access-logs.md
@@ -236,7 +236,7 @@ http 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188
 "GET http://www.example.com:80/ HTTP/1.1" "curl/7.46.0" - - 
 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067
 "Root=1-58337262-36d228ad5d99923122bbe354" "-" "-" 
-0 2018-07-02T22:22:48.364000Z "forward" "-" "-" 10.0.0.1:80 200 "-" "-"
+0 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.0.1:80" "200" "-" "-"
 ```
 
 **Example HTTPS Entry**  
@@ -248,7 +248,7 @@ https 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188
 "GET https://www.example.com:443/ HTTP/1.1" "curl/7.46.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 
 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067
 "Root=1-58337281-1d84f3d73c47ec4e58577259" "www.example.com" "arn:aws:acm:us-east-2:123456789012:certificate/12345678-1234-1234-1234-123456789012"
-1 2018-07-02T22:22:48.364000Z "authenticate,forward" "-" "-" 10.0.0.1:80 200 "-" "-"
+1 2018-07-02T22:22:48.364000Z "authenticate,forward" "-" "-" "10.0.0.1:80" "200" "-" "-"
 ```
 
 **Example HTTP/2 Entry**  
@@ -260,7 +260,7 @@ h2 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188
 "GET https://10.0.2.105:773/ HTTP/2.0" "curl/7.46.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2
 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067
 "Root=1-58337327-72bd00b0343d75b906739c42" "-" "-"
-1 2018-07-02T22:22:48.364000Z "redirect" "https://example.com:80/" "-" 10.0.0.66:9000 200 "-" "-"
+1 2018-07-02T22:22:48.364000Z "redirect" "https://example.com:80/" "-" "10.0.0.66:9000" "200" "-" "-"
 ```
 
 **Example WebSockets Entry**  
@@ -272,7 +272,7 @@ ws 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188
 "GET http://10.0.0.30:80/ HTTP/1.1" "-" - - 
 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067
 "Root=1-58337364-23a8c76965a2ef7629b185e3" "-" "-"
-1 2018-07-02T22:22:48.364000Z "forward" "-" "-" 10.0.1.192:8010 101 "-" "-"
+1 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.1.192:8010" "101" "-" "-"
 ```
 
 **Example Secured WebSockets Entry**  
@@ -284,7 +284,7 @@ wss 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188
 "GET https://10.0.0.30:443/ HTTP/1.1" "-" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 
 arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067
 "Root=1-58337364-23a8c76965a2ef7629b185e3" "-" "-"
-1 2018-07-02T22:22:48.364000Z "forward" "-" "-" 10.0.0.171:8010 101 "-" "-"
+1 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.0.171:8010" "101" "-" "-"
 ```
 
 **Example Entries for Lambda Functions**  


### PR DESCRIPTION
*Description of changes:*
Added missing double-quotes to "target:port_list" and "target_status_code_list" fields in the example log entries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
