### PR TITLE
Add note about ALB `multiValueHeaders`

### DIFF
--- a/doc_source/lambda-functions.md
+++ b/doc_source/lambda-functions.md
@@ -257,7 +257,7 @@ If you enable multi\-value headers, you must specify multiple cookies as follows
 }
 ```
 
-Please note that the order of the headers which are ultimately sent to an HTTP client is *undefined*. An Application Load Balancer may send the headers in the order specified in the Lambda response payload, it may reverse the headers, or it may send them in any other implementation-defined order.
+The load baalncer might send the headers to the client in a different order then the order specified in the Lambda response payload. Therefore, do not count on headers being returned in a specific order.
 
 ### Enable multi\-value headers<a name="enable-multi-value-headers"></a>
 

--- a/doc_source/lambda-functions.md
+++ b/doc_source/lambda-functions.md
@@ -257,6 +257,8 @@ If you enable multi\-value headers, you must specify multiple cookies as follows
 }
 ```
 
+Please note that the order of the headers which are ultimately sent to an HTTP client is *undefined*. An Application Load Balancer may send the headers in the order specified in the Lambda response payload, it may reverse the headers, or it may send them in any other implementation-defined order.
+
 ### Enable multi\-value headers<a name="enable-multi-value-headers"></a>
 
 You can enable or disable multi\-value headers for a target group with the target type `lambda`\.


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*
This adds an important clarification to the documentation about the order of response headers sent to an HTTP client against ALB Lambda targets.

I confirmed this with the ALB team via AWS Support [cases 11572778871 & 12008106771] that this behavior is intended.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
